### PR TITLE
file path fix

### DIFF
--- a/prepare.js
+++ b/prepare.js
@@ -48,7 +48,7 @@ folders.forEach((folder) => {
   fs.readdirSync(folder.path).forEach((file) => {
     if (folder.regex.test(file)) {
       console.log(`copying file ${file} to ${distJsFolder}`);
-      fs.copyFileSync(`${folder.path}\\${file}`, `${folder.outputFile}\\${file}`);
+      fs.copyFileSync(path.join(folder.path, file), path.join(folder.outputFile, file))
     }
   });
 });


### PR DESCRIPTION
Windows requires backslashes when calling locations in git bash, while Mac/Linux requires forward slashes.
That is why ```fs.copyFileSync(`${folder.path}\\${file}`, `${folder.outputFile}\\${file}`);``` will not work on linux and mac.